### PR TITLE
Add Select() method to HTMLInputElement.

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -2211,6 +2211,7 @@ func (e *HTMLInputElement) StepDown(n int) (err error) {
 		}
 	}()
 	e.Call("stepDown", n)
+	return nil
 }
 
 func (e *HTMLInputElement) StepUp(n int) (err error) {
@@ -2226,6 +2227,7 @@ func (e *HTMLInputElement) StepUp(n int) (err error) {
 		}
 	}()
 	e.Call("stepUp", n)
+	return nil
 }
 
 type HTMLKeygenElement struct {


### PR DESCRIPTION
- According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement, it has that method, just like https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement does (which this package already supports).
- Note that HTMLInputElement and HTMLTextAreaElement share many other common methods like CheckValidity, SetCustomValidity, SetSelectionRange, but this package only supports the latter.
- Tested and it works in latest stable Chrome.
