### PR TITLE
README: Improve install steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Package dom provides GopherJS bindings for the JavaScript DOM APIs.
 
 ## Install
 
-    go get honnef.co/go/js/dom
+    go get -u -d honnef.co/go/js/dom
 
 ## Documentation
 


### PR DESCRIPTION
- Using `-d` flag will prevent go from building the package after getting its source. This will be faster, and likely what the user wants, since they're likely to be building it with a different architecture.
- Using `-u` will ensure the users end up with the latest version of the package, regardless of whether they happened to have an older version or not. This is desirable because newer versions of the package are expected to have fewer problems than older.
- See https://github.com/dominikh/go-js-dom/issues/15#issuecomment-72346465.