### PR TITLE
Add  HTMLDialogElement, HTMLPictureElement,, HTMLSlotElement

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -290,6 +290,8 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLDataElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLDataListElement"):
 		return &HTMLDataListElement{BasicHTMLElement: el}
+	case js.Global.Get("HTMLDialogElement"):
+		return &HTMLDialogElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLDirectoryElement"):
 		return &HTMLDirectoryElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLDivElement"):
@@ -358,6 +360,8 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLParagraphElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLParamElement"):
 		return &HTMLParamElement{BasicHTMLElement: el}
+	case js.Global.Get("HTMLPictureElement"):
+		return &HTMLPictureElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLPreElement"):
 		return &HTMLPreElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLProgressElement"):
@@ -368,6 +372,8 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLScriptElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLSelectElement"):
 		return &HTMLSelectElement{BasicHTMLElement: el}
+	case js.Global.Get("HTMLSlotElement"):
+		return &HTMLSlotElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLSourceElement"):
 		return &HTMLSourceElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLSpanElement"):
@@ -2296,6 +2302,24 @@ func (e *HTMLDataListElement) Options() []*HTMLOptionElement {
 	return getOptions(e.Object, "options")
 }
 
+type HTMLDialogElement struct {
+	*BasicHTMLElement
+	Open        bool   `js:"open"`
+	ReturnValue string `js:"returnValue"`
+}
+
+func (e *HTMLDialogElement) Close(returnValue string) {
+	e.Call("close", returnValue)
+}
+
+func (e *HTMLDialogElement) Show() {
+	e.Call("show")
+}
+
+func (e *HTMLDialogElement) ShowModal() {
+	e.Call("showModal")
+}
+
 type HTMLDirectoryElement struct{ *BasicHTMLElement }
 type HTMLDivElement struct{ *BasicHTMLElement }
 
@@ -2768,6 +2792,7 @@ type HTMLParamElement struct {
 	Value string `js:"value"`
 }
 
+type HTMLPictureElement struct{ *BasicHTMLElement }
 type HTMLPreElement struct{ *BasicHTMLElement }
 
 type HTMLProgressElement struct {
@@ -2859,6 +2884,15 @@ func (e *HTMLSelectElement) CheckValidity() bool {
 
 func (e *HTMLSelectElement) SetCustomValidity(s string) {
 	e.Call("setCustomValidity", s)
+}
+
+type HTMLSlotElement struct {
+	*BasicHTMLElement
+	Name string `js:"name"`
+}
+
+func (e *HTMLSlotElement) AssignedNodes() []Element {
+	return nodeListToElements(e.Call("assignedNodes"))
 }
 
 type HTMLSourceElement struct {

--- a/dom.go
+++ b/dom.go
@@ -390,6 +390,8 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLTableRowElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLTableSectionElement"):
 		return &HTMLTableSectionElement{BasicHTMLElement: el}
+	case js.Global.Get("HTMLTemplateElement"):
+		return &HTMLTemplateElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLTextAreaElement"):
 		return &HTMLTextAreaElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLTimeElement"):
@@ -404,8 +406,6 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLUnknownElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLVideoElement"):
 		return &HTMLVideoElement{HTMLMediaElement: &HTMLMediaElement{BasicHTMLElement: el}}
-	case js.Global.Get("HTMLTemplateElement"):
-		return &HTMLTemplateElement{el}
 	case js.Global.Get("HTMLElement"):
 		return el
 	default:
@@ -2938,6 +2938,12 @@ func (e *HTMLTableSectionElement) InsertRow(index int) *HTMLTableRowElement {
 	return wrapHTMLElement(e.Call("insertRow", index)).(*HTMLTableRowElement)
 }
 
+type HTMLTemplateElement struct{ *BasicHTMLElement }
+
+func (e *HTMLTemplateElement) Content() DocumentFragment {
+	return wrapDocumentFragment(e.Get("content"))
+}
+
 type HTMLTextAreaElement struct {
 	*BasicHTMLElement
 	Autocomplete       string `js:"autocomplete"`
@@ -3027,12 +3033,6 @@ type HTMLUListElement struct{ *BasicHTMLElement }
 type HTMLUnknownElement struct{ *BasicHTMLElement }
 
 type HTMLVideoElement struct{ *HTMLMediaElement }
-
-type HTMLTemplateElement struct{ *BasicHTMLElement }
-
-func (e *HTMLTemplateElement) Content() DocumentFragment {
-	return wrapDocumentFragment(e.Get("content"))
-}
 
 type ValidityState struct {
 	*js.Object

--- a/dom.go
+++ b/dom.go
@@ -404,6 +404,8 @@ func wrapHTMLElement(o *js.Object) HTMLElement {
 		return &HTMLUnknownElement{BasicHTMLElement: el}
 	case js.Global.Get("HTMLVideoElement"):
 		return &HTMLVideoElement{HTMLMediaElement: &HTMLMediaElement{BasicHTMLElement: el}}
+	case js.Global.Get("HTMLTemplateElement"):
+		return &HTMLTemplateElement{el}
 	case js.Global.Get("HTMLElement"):
 		return el
 	default:
@@ -3025,6 +3027,12 @@ type HTMLUListElement struct{ *BasicHTMLElement }
 type HTMLUnknownElement struct{ *BasicHTMLElement }
 
 type HTMLVideoElement struct{ *HTMLMediaElement }
+
+type HTMLTemplateElement struct{ *BasicHTMLElement }
+
+func (e *HTMLTemplateElement) Content() DocumentFragment {
+	return wrapDocumentFragment(e.Get("content"))
+}
 
 type ValidityState struct {
 	*js.Object


### PR DESCRIPTION
It's a basic implementation for `HTMLDialogElement`, `HTMLPictureElemen`and `HTMLSlotElement`. I need to do more tests with the Slot. The `HTMLDialogElement` [is only supported on Chrome/Opera](https://caniuse.com/#feat=dialog), right now.

----------------------

Because it's only supported by Chrome, if the developer strictly uses the `close()` and `show()` and not relies on `method="dialog"`, it's possible make a simple *polyfill*, such as:

    el := dom.GetWindow().Document().QuerySelector("dialog#my-dialog")
	if dialog, ok := el.(*dom.HTMLDialogElement); ok {
		dialog.ShowModal()
	} else {
		el.SetAttribute("open", "true")
	}

Then, on CSS, do something like `dialog[open] { ... }`, which will work in both cases.

-------------------

The `PictureElement` has nothing special.

--------------

I need to test the `HTMLSlotElement`, because it has `. assignedNodes`, but also have `.assignedElements` and `assignedSlot`. The [Mozilla page](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement#Methods) just say about `.assignedNodes()`, however.