### PR TITLE
Add Element.Matches and Element.Closest

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -1516,6 +1516,7 @@ type Element interface {
 
 	Attributes() map[string]string
 	Class() *TokenList
+	Closest(string) Element
 	ID() string
 	SetID(string)
 	TagName() string
@@ -1527,6 +1528,7 @@ type Element interface {
 	GetElementsByTagNameNS(ns string, name string) []Element
 	HasAttribute(string) bool
 	HasAttributeNS(ns string, name string) bool
+	Matches(string) bool
 	QuerySelector(string) Element
 	QuerySelectorAll(string) []Element
 	RemoveAttribute(string)
@@ -1719,6 +1721,10 @@ func (e *BasicElement) SetClass(s string) {
 	e.Set("className", s)
 }
 
+func (e *BasicElement) Closest(s string) Element {
+	return wrapElement(e.Call("closest", s))
+}
+
 func (e *BasicElement) ID() string {
 	return e.Get("id").String()
 }
@@ -1757,6 +1763,10 @@ func (e *BasicElement) HasAttribute(s string) bool {
 
 func (e *BasicElement) HasAttributeNS(ns string, name string) bool {
 	return e.Call("hasAttributeNS", ns, name).Bool()
+}
+
+func (e *BasicElement) Matches(s string) bool {
+	return e.Call("matches", s).Bool()
 }
 
 func (e *BasicElement) QuerySelector(s string) Element {


### PR DESCRIPTION
This change add support for:

> **element . matches(selectors)**
> Returns true if matching selectors against element’s root yields element, and false otherwise.

> **element . closest(selectors)**
> Returns the first (starting at element) inclusive ancestor that matches selectors, and null otherwise.
