### PR TITLE
rebase WheelEvent on top of MouseEvent

### DIFF
--- a/events.go
+++ b/events.go
@@ -106,7 +106,7 @@ func wrapEvent(o *js.Object) Event {
 	case js.Global.Get("UserProximityEvent"):
 		return &UserProximityEvent{ev}
 	case js.Global.Get("WheelEvent"):
-		return &WheelEvent{BasicEvent: ev}
+		return &WheelEvent{MouseEvent: &MouseEvent{UIEvent: &UIEvent{ev}}}
 	default:
 		return ev
 	}
@@ -395,7 +395,7 @@ const (
 )
 
 type WheelEvent struct {
-	*BasicEvent
+	*MouseEvent
 	DeltaX    float64 `js:"deltaX"`
 	DeltaY    float64 `js:"deltaY"`
 	DeltaZ    float64 `js:"deltaZ"`

--- a/v2/events.go
+++ b/v2/events.go
@@ -108,7 +108,7 @@ func wrapEvent(o js.Value) Event {
 	case c.Equal(js.Global().Get("UserProximityEvent")):
 		return &UserProximityEvent{ev}
 	case c.Equal(js.Global().Get("WheelEvent")):
-		return &WheelEvent{BasicEvent: ev}
+		return &WheelEvent{MouseEvent: &MouseEvent{UIEvent: &UIEvent{ev}}}
 	default:
 		return ev
 	}
@@ -400,7 +400,7 @@ const (
 )
 
 type WheelEvent struct {
-	*BasicEvent
+	*MouseEvent
 }
 
 func (ev *WheelEvent) DeltaX() float64 { return ev.Get("deltaX").Float() }

--- a/v2/events_go113.go
+++ b/v2/events_go113.go
@@ -108,7 +108,7 @@ func wrapEvent(o js.Value) Event {
 	case js.Global().Get("UserProximityEvent"):
 		return &UserProximityEvent{ev}
 	case js.Global().Get("WheelEvent"):
-		return &WheelEvent{BasicEvent: ev}
+		return &WheelEvent{MouseEvent: &MouseEvent{UIEvent: &UIEvent{ev}}}
 	default:
 		return ev
 	}
@@ -400,7 +400,7 @@ const (
 )
 
 type WheelEvent struct {
-	*BasicEvent
+	*MouseEvent
 }
 
 func (ev *WheelEvent) DeltaX() float64 { return ev.Get("deltaX").Float() }


### PR DESCRIPTION
According to documentation on MDN¹, the WheelEvent interface
inherits properties from MouseEvent, which in turn inherits from
UIEvent, and that inherits from Event.

Embed MouseEvent in WheelEvent type in order to gain access to
additional properties in WheelEvent.

[1] https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent

Fixes #68.