### PR TITLE
rebase PointerEvent on top of MouseEvent

### DIFF
--- a/events.go
+++ b/events.go
@@ -76,7 +76,7 @@ func wrapEvent(o *js.Object) Event {
 	case js.Global.Get("PageTransitionEvent"):
 		return &PageTransitionEvent{ev}
 	case js.Global.Get("PointerEvent"):
-		return &PointerEvent{ev}
+		return &PointerEvent{&MouseEvent{UIEvent: &UIEvent{ev}}}
 	case js.Global.Get("PopStateEvent"):
 		return &PopStateEvent{ev}
 	case js.Global.Get("ProgressEvent"):
@@ -298,7 +298,7 @@ func (ev *MouseEvent) ModifierState(mod string) bool {
 type MutationEvent struct{ *BasicEvent }
 type OfflineAudioCompletionEvent struct{ *BasicEvent }
 type PageTransitionEvent struct{ *BasicEvent }
-type PointerEvent struct{ *BasicEvent }
+type PointerEvent struct{ *MouseEvent }
 type PopStateEvent struct{ *BasicEvent }
 type ProgressEvent struct{ *BasicEvent }
 type RelatedEvent struct{ *BasicEvent }

--- a/v2/dom.go
+++ b/v2/dom.go
@@ -1,5 +1,5 @@
-// +build js
-// +build go1.14
+//go:build js && go1.14
+// +build js,go1.14
 
 // Package dom provides Go bindings for the JavaScript DOM APIs.
 //

--- a/v2/dom_go113.go
+++ b/v2/dom_go113.go
@@ -1,5 +1,5 @@
-// +build js
-// +build !go1.14
+//go:build js && !go1.14
+// +build js,!go1.14
 
 // Package dom provides Go bindings for the JavaScript DOM APIs.
 //

--- a/v2/dom_test.go
+++ b/v2/dom_test.go
@@ -1,3 +1,4 @@
+//go:build js
 // +build js
 
 package dom

--- a/v2/events.go
+++ b/v2/events.go
@@ -1,5 +1,5 @@
-// +build js
-// +build go1.14
+//go:build js && go1.14
+// +build js,go1.14
 
 package dom
 
@@ -78,7 +78,7 @@ func wrapEvent(o js.Value) Event {
 	case c.Equal(js.Global().Get("PageTransitionEvent")):
 		return &PageTransitionEvent{ev}
 	case c.Equal(js.Global().Get("PointerEvent")):
-		return &PointerEvent{ev}
+		return &PointerEvent{&MouseEvent{&UIEvent{ev}}}
 	case c.Equal(js.Global().Get("PopStateEvent")):
 		return &PopStateEvent{ev}
 	case c.Equal(js.Global().Get("ProgressEvent")):
@@ -301,7 +301,7 @@ func (ev *MouseEvent) ModifierState(mod string) bool {
 type MutationEvent struct{ *BasicEvent }
 type OfflineAudioCompletionEvent struct{ *BasicEvent }
 type PageTransitionEvent struct{ *BasicEvent }
-type PointerEvent struct{ *BasicEvent }
+type PointerEvent struct{ *MouseEvent }
 type PopStateEvent struct{ *BasicEvent }
 type ProgressEvent struct{ *BasicEvent }
 type RelatedEvent struct{ *BasicEvent }

--- a/v2/events_go113.go
+++ b/v2/events_go113.go
@@ -1,5 +1,5 @@
-// +build js
-// +build !go1.14
+//go:build js && !go1.14
+// +build js,!go1.14
 
 package dom
 
@@ -78,7 +78,7 @@ func wrapEvent(o js.Value) Event {
 	case js.Global().Get("PageTransitionEvent"):
 		return &PageTransitionEvent{ev}
 	case js.Global().Get("PointerEvent"):
-		return &PointerEvent{ev}
+		return &PointerEvent{&MouseEvent{&UIEvent{ev}}}
 	case js.Global().Get("PopStateEvent"):
 		return &PopStateEvent{ev}
 	case js.Global().Get("ProgressEvent"):
@@ -301,7 +301,7 @@ func (ev *MouseEvent) ModifierState(mod string) bool {
 type MutationEvent struct{ *BasicEvent }
 type OfflineAudioCompletionEvent struct{ *BasicEvent }
 type PageTransitionEvent struct{ *BasicEvent }
-type PointerEvent struct{ *BasicEvent }
+type PointerEvent struct{ *MouseEvent }
 type PopStateEvent struct{ *BasicEvent }
 type ProgressEvent struct{ *BasicEvent }
 type RelatedEvent struct{ *BasicEvent }


### PR DESCRIPTION
According to documentation on MDN¹, the PointerEvent interface
inherits properties from MouseEvent, which in turn inherits from
UIEvent, and that inherits from Event.

Embed MouseEvent in PointerEvent type in order to gain access to
additional properties in PointerEvent.

This is similar to what was done to WheelEvent in Pull Request #77.

¹ https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent