### PR TITLE
add PointerID and PointerType to PointerEvent, as well as DataTransfer.SetData

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -3129,3 +3129,7 @@ type DataTransfer struct{ *js.Object }
 func (dt *DataTransfer) GetData(format string) string {
 	return dt.Call("getData", format).String()
 }
+
+func (dt *DataTransfer) SetData(format, data string) {
+	dt.Call("setData", format, data)
+}

--- a/events.go
+++ b/events.go
@@ -76,7 +76,7 @@ func wrapEvent(o *js.Object) Event {
 	case js.Global.Get("PageTransitionEvent"):
 		return &PageTransitionEvent{ev}
 	case js.Global.Get("PointerEvent"):
-		return &PointerEvent{&MouseEvent{UIEvent: &UIEvent{ev}}}
+		return &PointerEvent{MouseEvent: &MouseEvent{UIEvent: &UIEvent{ev}}}
 	case js.Global.Get("PopStateEvent"):
 		return &PopStateEvent{ev}
 	case js.Global.Get("ProgressEvent"):
@@ -307,7 +307,13 @@ func (ev *MouseEvent) ModifierState(mod string) bool {
 type MutationEvent struct{ *BasicEvent }
 type OfflineAudioCompletionEvent struct{ *BasicEvent }
 type PageTransitionEvent struct{ *BasicEvent }
-type PointerEvent struct{ *MouseEvent }
+
+type PointerEvent struct {
+	*MouseEvent
+	PointerID   int    `js:"pointerId"`
+	PointerType string `js:"pointerType"`
+}
+
 type PopStateEvent struct{ *BasicEvent }
 type ProgressEvent struct{ *BasicEvent }
 type RelatedEvent struct{ *BasicEvent }

--- a/v2/dom.go
+++ b/v2/dom.go
@@ -3363,3 +3363,7 @@ type DataTransfer struct{ js.Value }
 func (dt *DataTransfer) GetData(format string) string {
 	return dt.Call("getData", format).String()
 }
+
+func (dt *DataTransfer) SetData(format, data string) {
+	dt.Call("setData", format, data)
+}

--- a/v2/events.go
+++ b/v2/events.go
@@ -310,7 +310,12 @@ func (ev *MouseEvent) ModifierState(mod string) bool {
 type MutationEvent struct{ *BasicEvent }
 type OfflineAudioCompletionEvent struct{ *BasicEvent }
 type PageTransitionEvent struct{ *BasicEvent }
+
 type PointerEvent struct{ *MouseEvent }
+
+func (ev *PointerEvent) PointerID() int      { return ev.Get("pointerId").Int() }
+func (ev *PointerEvent) PointerType() string { return ev.Get("pointerType").String() }
+
 type PopStateEvent struct{ *BasicEvent }
 type ProgressEvent struct{ *BasicEvent }
 type RelatedEvent struct{ *BasicEvent }


### PR DESCRIPTION
I plan to merge this in a few days. This PR exists so that it's possible to leave review comments before then, but a review is not required. Thanks.

References:

- https://developer.mozilla.org/docs/Web/API/PointerEvent/pointerId
- https://developer.mozilla.org/docs/Web/API/PointerEvent/pointerType
- https://developer.mozilla.org/docs/Web/API/DataTransfer/setData